### PR TITLE
매장 등록, 매장 등록 시 예외처리 추가 및 회원가입 기능 일부 추가

### DIFF
--- a/src/main/java/com/intbyte/wizbuddy/exception/EmailDuplicateException.java
+++ b/src/main/java/com/intbyte/wizbuddy/exception/EmailDuplicateException.java
@@ -1,4 +1,0 @@
-package com.intbyte.wizbuddy.exception;
-
-public class EmailDuplicateException extends Throwable {
-}

--- a/src/main/java/com/intbyte/wizbuddy/exception/StatusEnum.java
+++ b/src/main/java/com/intbyte/wizbuddy/exception/StatusEnum.java
@@ -1,0 +1,19 @@
+package com.intbyte.wizbuddy.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum StatusEnum {
+
+    USER_NOT_FOUND(404,"USER_NOT_FOUND"),
+    EMAIL_DUPLICATE(403, "EMAIL_DUPLICATE"),
+    BUSINESS_NUM_DUPLICATE(403, "BUSINESS_NUM_DUPLICATE");
+
+    private final int statusCode;
+    private final String code;
+
+    StatusEnum(int statusCode, String code) {
+        this.statusCode = statusCode;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/intbyte/wizbuddy/exception/shop/BusinessNumDuplicateException.java
+++ b/src/main/java/com/intbyte/wizbuddy/exception/shop/BusinessNumDuplicateException.java
@@ -1,0 +1,15 @@
+package com.intbyte.wizbuddy.exception.shop;
+
+import com.intbyte.wizbuddy.exception.StatusEnum;
+
+public class BusinessNumDuplicateException extends IllegalArgumentException {
+
+    private final StatusEnum status;
+
+    private static final String message = "이미 등록된 매장입니다.";
+
+    public BusinessNumDuplicateException() {
+        super(message);
+        this.status = StatusEnum.BUSINESS_NUM_DUPLICATE;
+    }
+}

--- a/src/main/java/com/intbyte/wizbuddy/exception/user/EmailDuplicateException.java
+++ b/src/main/java/com/intbyte/wizbuddy/exception/user/EmailDuplicateException.java
@@ -1,0 +1,15 @@
+package com.intbyte.wizbuddy.exception.user;
+
+import com.intbyte.wizbuddy.exception.StatusEnum;
+
+public class EmailDuplicateException extends IllegalArgumentException {
+
+    private final StatusEnum status;
+
+    private static final String message = "이미 등록된 이메일입니다.";
+
+    public EmailDuplicateException() {
+        super(message);
+        this.status = StatusEnum.EMAIL_DUPLICATE;
+    }
+}

--- a/src/main/java/com/intbyte/wizbuddy/exception/user/EmployerNotFoundException.java
+++ b/src/main/java/com/intbyte/wizbuddy/exception/user/EmployerNotFoundException.java
@@ -1,0 +1,15 @@
+package com.intbyte.wizbuddy.exception.user;
+
+import com.intbyte.wizbuddy.exception.StatusEnum;
+
+public class EmployerNotFoundException extends IllegalArgumentException {
+
+    private final StatusEnum status;
+
+    private static final String message = "존재하지 않는 사용자입니다.";
+
+    public EmployerNotFoundException() {
+        super(message);
+        this.status = StatusEnum.USER_NOT_FOUND;
+    }
+}

--- a/src/main/java/com/intbyte/wizbuddy/mapper/ShopMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/ShopMapper.java
@@ -4,4 +4,5 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface ShopMapper {
+    String findByBusinessNum(String businessNum);
 }

--- a/src/main/java/com/intbyte/wizbuddy/shop/domain/entity/Shop.java
+++ b/src/main/java/com/intbyte/wizbuddy/shop/domain/entity/Shop.java
@@ -1,13 +1,7 @@
 package com.intbyte.wizbuddy.shop.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -15,37 +9,38 @@ import java.time.LocalTime;
 @Entity(name = "shop")
 @Table(name = "shop")
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
 public class Shop {
 
     @Id
-    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shop_code")
     private int shopCode;
 
-    @Column
+    @Column(name = "shop_name")
     private String shopName;
 
-    @Column
+    @Column(name = "shop_location")
     private String shopLocation;
 
-    @Column
+    @Column(name = "shop_flag")
     private Boolean shopFlag;
 
-    @Column
+    @Column(name = "shop_open_time")
     private LocalTime shopOpenTime;
 
-    @Column
+    @Column(name = "business_num")
     private String businessNum;
 
-    @Column
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    // employeeCode -> fk
-    @Column
+    @Column(name = "employer_code")
     private Integer employerCode;
 }

--- a/src/main/java/com/intbyte/wizbuddy/shop/dto/ShopDTO.java
+++ b/src/main/java/com/intbyte/wizbuddy/shop/dto/ShopDTO.java
@@ -7,8 +7,7 @@ import java.time.LocalTime;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-@Setter
+@Getter @Setter
 @ToString
 public class ShopDTO {
     private int shopCode;
@@ -19,5 +18,5 @@ public class ShopDTO {
     private String businessNum;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private Integer employerCode;
+    private int employerCode;
 }

--- a/src/main/java/com/intbyte/wizbuddy/shop/repository/ShopRepository.java
+++ b/src/main/java/com/intbyte/wizbuddy/shop/repository/ShopRepository.java
@@ -1,0 +1,7 @@
+package com.intbyte.wizbuddy.shop.repository;
+
+import com.intbyte.wizbuddy.shop.domain.entity.Shop;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopRepository extends JpaRepository<Shop, Integer> {
+}

--- a/src/main/java/com/intbyte/wizbuddy/shop/service/ShopService.java
+++ b/src/main/java/com/intbyte/wizbuddy/shop/service/ShopService.java
@@ -1,4 +1,49 @@
 package com.intbyte.wizbuddy.shop.service;
 
+import com.intbyte.wizbuddy.exception.shop.BusinessNumDuplicateException;
+import com.intbyte.wizbuddy.mapper.ShopMapper;
+import com.intbyte.wizbuddy.shop.domain.entity.Shop;
+import com.intbyte.wizbuddy.shop.dto.ShopDTO;
+import com.intbyte.wizbuddy.shop.repository.ShopRepository;
+import com.intbyte.wizbuddy.user.repository.EmployerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Service
+@RequiredArgsConstructor
 public class ShopService {
+
+    private final EmployerRepository employerRepository;
+    private final ShopRepository shopRepository;
+    private final ShopMapper shopMapper;
+
+    @Transactional
+    public void registerShop(ShopDTO shopInfo) {
+//        employerRepository.findById(employerCode).orElseThrow(EmployerNotFoundException::new);
+
+        String shopName = shopInfo.getShopName();
+        String shopLocation = shopInfo.getShopLocation();
+        LocalTime shopOpenTime = shopInfo.getShopOpenTime();
+        String businessNum = shopInfo.getBusinessNum();
+        int employerCode = shopInfo.getEmployerCode();
+
+        if (shopMapper.findByBusinessNum(businessNum) != null) throw new BusinessNumDuplicateException();
+
+        Shop shop = Shop.builder()
+                .shopName(shopName)
+                .shopLocation(shopLocation)
+                .shopFlag(true)
+                .shopOpenTime(shopOpenTime)
+                .businessNum(businessNum)
+                .employerCode(employerCode)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        shopRepository.save(shop);
+    }
 }

--- a/src/main/java/com/intbyte/wizbuddy/user/domain/entity/Employer.java
+++ b/src/main/java/com/intbyte/wizbuddy/user/domain/entity/Employer.java
@@ -1,9 +1,6 @@
 package com.intbyte.wizbuddy.user.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -18,30 +15,31 @@ import java.time.LocalDateTime;
 public class Employer {
 
     @Id
-    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "employer_code")
     private int employerCode;
 
-    @Column
+    @Column(name = "employer_name")
     private String employerName;
 
-    @Column
+    @Column(name = "employer_email")
     private String employerEmail;
 
-    @Column
+    @Column(name = "employer_password")
     private String employerPassword;
 
-    @Column
+    @Column(name = "employer_phone")
     private String employerPhone;
 
-    @Column
+    @Column(name = "employer_flag")
     private boolean employerFlag;
 
-    @Column
+    @Column(name = "employer_black_state")
     private boolean employerBlackState;
 
-    @Column
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/intbyte/wizbuddy/user/service/EmployerService.java
+++ b/src/main/java/com/intbyte/wizbuddy/user/service/EmployerService.java
@@ -1,6 +1,6 @@
 package com.intbyte.wizbuddy.user.service;
 
-import com.intbyte.wizbuddy.exception.EmailDuplicateException;
+import com.intbyte.wizbuddy.exception.user.EmailDuplicateException;
 import com.intbyte.wizbuddy.user.domain.entity.Employer;
 import com.intbyte.wizbuddy.user.dto.EmployerDTO;
 import com.intbyte.wizbuddy.user.repository.EmployerRepository;

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/ShopMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/ShopMapper.xml
@@ -2,6 +2,24 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper>
 
+<mapper namespace="com.intbyte.wizbuddy.mapper.ShopMapper">
+    <resultMap type="com.intbyte.wizbuddy.shop.dto.ShopDTO" id="shopResultMap">
+        <id property="shopCode" column="shop_code"/>
+        <result property="shopName" column="shop_name"/>
+        <result property="shopLocation" column="shop_location"/>
+        <result property="shopFlag" column="shop_flag"/>
+        <result property="shopOpenTime" column="shop_open_time"/>
+        <result property="businessNum" column="business_num"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+        <result property="employerCode" column="employer_code"/>
+    </resultMap>
+
+    <select id="findByBusinessNum" resultType="string" parameterType="string">
+        SELECT
+            S.business_num
+        FROM shop S
+        WHERE S.business_num = #{ businessNum }
+    </select>
 </mapper>

--- a/src/test/java/com/intbyte/wizbuddy/shop/service/ShopServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/shop/service/ShopServiceTests.java
@@ -1,0 +1,60 @@
+package com.intbyte.wizbuddy.shop.service;
+
+import com.intbyte.wizbuddy.exception.shop.BusinessNumDuplicateException;
+import com.intbyte.wizbuddy.shop.domain.entity.Shop;
+import com.intbyte.wizbuddy.shop.dto.ShopDTO;
+import com.intbyte.wizbuddy.shop.repository.ShopRepository;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ShopServiceTests {
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Autowired
+    private ShopService shopService;
+
+    @Test
+    @DisplayName("매장 등록 성공")
+    @Transactional
+    void testRegisterShopSuccess() {
+        // given
+        int employerCode = 1;
+        List<Shop> currentShopList = shopRepository.findAll();
+        ShopDTO shopDTO = new ShopDTO(currentShopList.size() + 1, "Test Shop", "Test Location", true, LocalTime.of(9, 0), "999-99-99999", LocalDateTime.now(), LocalDateTime.now(), employerCode);
+
+        // when
+        shopService.registerShop(shopDTO);
+
+        // then
+        List<Shop> newShops = shopRepository.findAll();
+        Shop shop = newShops.get(newShops.size() - 1);
+
+        Assertions.assertThat(shop.getBusinessNum()).isEqualTo(shopDTO.getBusinessNum());
+    }
+
+    @Test
+    @DisplayName("사업자 번호 중복으로 매장 등록 실패")
+    @Transactional
+    void testRegisterShopThrowsBusinessNumDuplicateException() {
+        // given
+        int employerCode = 1;
+        List<Shop> currentShopList = shopRepository.findAll();
+        ShopDTO shopDTO = new ShopDTO(currentShopList.size() + 1, "Test Shop", "Test Location", true, LocalTime.of(9, 0), "123-45-67890", LocalDateTime.now(), LocalDateTime.now(), employerCode);
+
+        // when & then
+        assertThrows(BusinessNumDuplicateException.class, () -> shopService.registerShop(shopDTO));
+    }
+}


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

매장 등록을 하기 위해서는 원래는 유저가 등록을 해야 하기에 새로운 유저를 등록하기 위한 회원가입과 관련된 로직을 만들던 와중 간단하게 매장을 임의로 추가하고 Jpa를 활용해 테스트까지 하는 과정을 구현해봤습니다.

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 엔티티 컬럼들을 수정했습니다.

## 관련 스크린 샷 

## 테스트 계획 또는 완료 사항
- [x] 매장 등록 성공
- [x] 사업자 등록 번호 중복으로 인한 예외처리 테스트 성공
