### PR TITLE
Kyeong seok

### DIFF
--- a/src/main/java/com/intbyte/wizbuddy/mapper/TaskMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/TaskMapper.java
@@ -1,7 +1,13 @@
 package com.intbyte.wizbuddy.mapper;
 
+import com.intbyte.wizbuddy.task.domain.entity.Task;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface TaskMapper {
+    Task findTaskById(int taskId);
+
+    List<Task> findAllTask();
 }

--- a/src/main/java/com/intbyte/wizbuddy/task/domain/entity/Task.java
+++ b/src/main/java/com/intbyte/wizbuddy/task/domain/entity/Task.java
@@ -4,37 +4,34 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
-
-@Entity(name = "task")
+@Entity
 @Table(name = "task")
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @ToString
+@EqualsAndHashCode
 public class Task {
 
     @Id
-    @Column
+    @Column(name = "task_code")
     private int taskCode;
 
-    @Column
+    @Column(name = "task_contents")
     private String taskContents;
 
-    @Column
+    @Column(name = "task_flag")
     private boolean taskFlag;
 
-    @Column
+    @Column(name = "task_fixed_state")
     private boolean taskFixedState;
 
-    @Column
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    @Column
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/intbyte/wizbuddy/task/dto/TaskDTO.java
+++ b/src/main/java/com/intbyte/wizbuddy/task/dto/TaskDTO.java
@@ -9,17 +9,18 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
+@EqualsAndHashCode
 public class TaskDTO {
 
-    private int TaskCode;
+    private int taskCode;
 
-    private String TaskContents;
+    private String taskContents;
 
-    private boolean TaskFlag;
+    private boolean taskFlag;
 
-    private boolean TaskFixedState;
+    private boolean taskFixedState;
 
-    private LocalDateTime CreatedAt;
+    private LocalDateTime createdAt;
 
-    private LocalDateTime UpdatedAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/intbyte/wizbuddy/task/repository/TaskRepository.java
+++ b/src/main/java/com/intbyte/wizbuddy/task/repository/TaskRepository.java
@@ -1,0 +1,10 @@
+package com.intbyte.wizbuddy.task.repository;
+
+import com.intbyte.wizbuddy.task.domain.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Integer> {
+
+}

--- a/src/main/java/com/intbyte/wizbuddy/task/service/TaskService.java
+++ b/src/main/java/com/intbyte/wizbuddy/task/service/TaskService.java
@@ -1,4 +1,67 @@
 package com.intbyte.wizbuddy.task.service;
 
+import com.intbyte.wizbuddy.mapper.TaskMapper;
+import com.intbyte.wizbuddy.task.domain.entity.Task;
+import com.intbyte.wizbuddy.task.dto.TaskDTO;
+import com.intbyte.wizbuddy.task.repository.TaskRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
 public class TaskService {
+
+    private final TaskRepository taskRepository; // jpa
+    private final TaskMapper mapper;        // mybatis
+    private final ModelMapper modelMapper; // dto <-> entity 변환
+
+    @Autowired
+    public TaskService(TaskRepository taskRepository, TaskMapper mapper, ModelMapper modelMapper) {
+        this.taskRepository = taskRepository;
+        this.mapper = mapper;
+        this.modelMapper = modelMapper;
+    }
+
+    // task는 mapper 사용하기
+    // checklist는 mapper 사용 x로 진행.
+
+    // 1. 업무 등록을 해야함. -> 사용자에게서 TaskDTO가 넘어올거임. -> 리턴도 DTO로 해야함. -> 등록은 void?
+    // void로 하지말고 dto에 등록된 업무를 보내주는게 맞을듯? dto 리턴이 맞는거같다.
+    @Transactional
+    public TaskDTO insertTask(TaskDTO taskDTO) {
+        Task insertTask = new Task(taskDTO.getTaskCode(), taskDTO.getTaskContents(), taskDTO.isTaskFlag()
+                            , taskDTO.isTaskFixedState(), taskDTO.getCreatedAt(), taskDTO.getUpdatedAt());
+
+        //        modelMapper.map(taskDTO, insertTask);
+        //        Task insertTask1 = modelMapper.map(taskDTO, Task.class); //ModelMapper는 필드명이 같다면 자동으로 매핑해주며, 복잡한 객체 매핑도 가능합니다.
+
+        taskRepository.save(insertTask);
+
+        return modelMapper.map(insertTask, TaskDTO.class);
+    }
+
+    // 2. 업무 조회 (id로 task 조회, 모든 업무 조회)
+    // 2-1. id로 1개의 task 조회
+    @Transactional
+    public TaskDTO findTaskById(int taskCode){ // by mybatis
+
+        Task findTask = mapper.findTaskById(taskCode);
+        return modelMapper.map(findTask, TaskDTO.class);
+}
+
+    // 2-2. 전체 task 조회
+    @Transactional
+    public List<TaskDTO> findAllTask(){
+
+        List<Task> findTasks = mapper.findAllTask();
+
+        return findTasks.stream()
+                .map(task -> modelMapper.map(task, TaskDTO.class))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/intbyte/wizbuddy/task/service/TaskService.java
+++ b/src/main/java/com/intbyte/wizbuddy/task/service/TaskService.java
@@ -79,4 +79,27 @@ public class TaskService {
         return modelMapper.map(updatedTask, TaskDTO.class);
     }
 
+    // 4. 업무 삭제 (id값에 해당하는 task 삭제)
+    @Transactional
+    public TaskDTO deleteTask(TaskDTO taskDTO){
+
+        int taskCode = taskDTO.getTaskCode();
+        Task deleteTask = taskRepository.findById(taskCode).orElseThrow(IllegalArgumentException::new);
+
+        // 1. taskDTO로 바꿔주기
+        TaskDTO deletedTaskDTO = modelMapper.map(deleteTask, TaskDTO.class);
+        deletedTaskDTO.setTaskFlag(false);
+
+        // 2. task로 바꿔주기
+        Task deleteTask2 = new Task(deletedTaskDTO.getTaskCode(), deletedTaskDTO.getTaskContents(), deletedTaskDTO.isTaskFlag(),
+                deletedTaskDTO.isTaskFixedState(), deletedTaskDTO.getCreatedAt(), deletedTaskDTO.getUpdatedAt());
+
+        taskRepository.save(deleteTask2);
+
+        return deletedTaskDTO;
+    }
+
+    // 일단 반환값과 파라미터값을 어떻게 할지 안정한거같아서 모두 통일함. (return = TaskDTO / parameter = TaskDTO)
+    // ------------
+    // 5. 체크리스트
 }

--- a/src/main/java/com/intbyte/wizbuddy/task/service/TaskService.java
+++ b/src/main/java/com/intbyte/wizbuddy/task/service/TaskService.java
@@ -64,4 +64,19 @@ public class TaskService {
                 .collect(Collectors.toList());
     }
 
+    // 3. 업무 수정(id값에 해당하는 업무 수정)
+    @Transactional
+    public TaskDTO modifyTask(TaskDTO taskDTO){
+
+        int taskCode = taskDTO.getTaskCode();
+        Task task = taskRepository.findById(taskCode).orElseThrow(IllegalArgumentException::new);
+        // task를 taskdto로 수정
+
+        modelMapper.map(taskDTO, task); // task를 taskdto로 수정
+
+        Task updatedTask = taskRepository.save(task);
+
+        return modelMapper.map(updatedTask, TaskDTO.class);
+    }
+
 }

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/TaskMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/TaskMapper.xml
@@ -2,6 +2,41 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper>
+<mapper namespace="com.intbyte.wizbuddy.mapper.TaskMapper">
+    <resultMap type="com.intbyte.wizbuddy.task.domain.entity.Task" id="taskResultMap">
+        <id property="taskCode" column="task_code"/>
+        <result property="taskContents" column="task_contents"/>
+        <result property="taskFlag" column="task_flag"/>
+        <result property="taskFixedState" column="task_fixed_state"/> <!-- column은 db 컬럼명과 동일해야함. -->
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <!-- parameterType이 뭔지 알아보기
+    parameterType : 비즈니스 로직으로부터 전달 받은, SQL 구문에 사용될 매개변수의 자료형
+    이 속성은 이 쿼리가 실행될 때 전달받는 파라미터의 타입을 명시-->
+    <select id="findAllTask" resultMap="taskResultMap">
+        SELECT
+              A.task_code
+            , A.task_contents
+            , A.task_flag
+            , A.task_fixed_state
+            , A.created_at
+            , A.updated_at
+         FROM Task A
+    </select>
+
+    <select id="findTaskById" resultMap="taskResultMap" parameterType="int">
+        SELECT
+              A.task_code
+            , A.task_contents
+            , A.task_flag
+            , A.task_fixed_state
+            , A.created_at
+            , A.updated_at
+         FROM Task A
+        WHERE A.task_code = #{ taskCode }
+    </select>
+
 
 </mapper>

--- a/src/test/java/com/intbyte/wizbuddy/task/service/TaskServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/task/service/TaskServiceTests.java
@@ -1,0 +1,107 @@
+package com.intbyte.wizbuddy.task.service;
+
+import com.intbyte.wizbuddy.mapper.TaskMapper;
+import com.intbyte.wizbuddy.task.domain.entity.Task;
+import com.intbyte.wizbuddy.task.dto.TaskDTO;
+import com.intbyte.wizbuddy.task.repository.TaskRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class TaskServiceTests {
+    @Autowired
+    private TaskService taskService;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private TaskMapper taskMapper;
+
+
+    // 1. 업무 1개 insert
+    @Test
+//    @Transactional // insert 후 select하는 경우 각 메서드가 transactional이라 commit이 되지 않아 찾을수가 없어서 뺐음.
+    // insert 테스트의 정의를 다르게 하면 (select를 하지 않는다면) @Transactional을 적어도 됨.
+    public void 업무_1개_추가_테스트() {
+        // given: 테스트 데이터 생성
+        TaskDTO newTaskDTO = new TaskDTO(12, "newTask", true, true,
+                LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS), LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // when: 서비스 메서드 호출
+        taskService.insertTask(newTaskDTO);
+        TaskDTO findTaskDTOById = taskService.findTaskById(12);
+
+        // then: 동등한지 비교
+        assertEquals(newTaskDTO, findTaskDTOById);
+    }
+
+    // 2-1. id로 업무 1개 조회
+    @Test
+    @Transactional
+    public void id로_업무_1개_조회_테스트(){
+
+        // given
+        int taskId = 1;
+        Task taskById = taskMapper.findTaskById(taskId);
+        System.out.println(taskById);
+        // when
+
+        // then
+    }
+
+    // 2-2. 전체 업무 조회
+    @Test
+    @Transactional
+    public void 전체_업무_조회_테스트(){
+        List<Task> allTask = taskMapper.findAllTask();
+        for (int i = 0; i < allTask.size(); i++) {
+            System.out.println(allTask.get(i));
+        }
+    }
+
+    // 3.업무 수정
+    @Test
+    public void id로_업무_1개_수정_테스트(){
+
+        // given: 수정할 Task 생성하기
+        Task modifyTask = new Task(1, "수정된 내용", true, true,
+                LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS), LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // when: 수정된 Task 가져오기, db에서 id로 task 가져오기
+        Task savedTask = taskRepository.save(modifyTask);
+        Task findTaskById = taskMapper.findTaskById(modifyTask.getTaskCode());
+
+        // then: 2개의 task contents가 동일한지 확인
+        Assertions.assertEquals(modifyTask.getTaskContents(), findTaskById.getTaskContents());
+    }
+
+    // 4. 업무 삭제
+    @Test
+    public void id_로_업무_1개_삭제_테스트(){
+
+        // given: 삭제하고싶은 task_code 생성
+        int deleteTaskId = 12;
+        TaskDTO findTaskDTOById = taskService.findTaskById(deleteTaskId);
+
+        // when: task_code가 12인 게시글 삭제(taskFlag가 false)
+        taskService.deleteTask(findTaskDTOById);
+        TaskDTO afterModifyTaskDTO = taskService.findTaskById(deleteTaskId);
+
+        // then: task_code가 12인 게시글의 state가 false인지 확인
+        assertEquals(false, afterModifyTaskDTO.isTaskFlag());
+    }
+}


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 업무 삭제의 경우 hard delete가 아닌 soft delete로 진행하도록 결정했기 때문에 Task를 받아온 후 TaskDTO로 변환하고 task_flag를 false로 바꾸고 save 합니다.

## 테스트 완료 사항
- [x] 테스트항목 1 업무 등록
- [x] 테스트항목 2 업무 1개 조회
- [x] 테스트항목 3 전체 업무 조회
- [x] 테스트항목 4 업무 수정
- [x] 테스트항목 5 업무 삭제

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/298bf831-7845-4dbe-bacd-eb21318e0386)


## 추가할 점
- [ ] 업무가 존재하지 않을 때 조회, 수정, 삭제를 하는 경우 TaskNotFoundException 예외처리 추가

close #43 
close #45 
close #47 
close #48 