### PR TITLE
✨ 기능 추가: TaskPerCheckList 엔티티 등록 및 insert 메서드 생성

### DIFF
--- a/src/main/java/com/intbyte/wizbuddy/mapper/TaskPerCheckListMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/TaskPerCheckListMapper.java
@@ -1,0 +1,11 @@
+package com.intbyte.wizbuddy.mapper;
+
+import com.intbyte.wizbuddy.taskperchecklist.domain.entity.TaskPerCheckList;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+//@Mapper
+public interface TaskPerCheckListMapper {
+//    List<TaskPerCheckList> findAllTaskPerCheckList();
+}

--- a/src/main/java/com/intbyte/wizbuddy/taskperchecklist/domain/EditTaskPerCheckListInfo.java
+++ b/src/main/java/com/intbyte/wizbuddy/taskperchecklist/domain/EditTaskPerCheckListInfo.java
@@ -1,0 +1,5 @@
+package com.intbyte.wizbuddy.taskperchecklist.domain;
+
+public class EditTaskPerCheckListInfo {
+
+}

--- a/src/main/java/com/intbyte/wizbuddy/taskperchecklist/domain/entity/TaskPerCheckList.java
+++ b/src/main/java/com/intbyte/wizbuddy/taskperchecklist/domain/entity/TaskPerCheckList.java
@@ -1,0 +1,49 @@
+package com.intbyte.wizbuddy.taskperchecklist.domain.entity;
+
+import com.intbyte.wizbuddy.checklist.domain.entity.CheckList;
+import com.intbyte.wizbuddy.task.domain.entity.Task;
+import com.intbyte.wizbuddy.user.domain.entity.Employee;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "taskperchecklist")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@Builder
+@EqualsAndHashCode
+public class TaskPerCheckList {
+
+    @EmbeddedId
+    private TaskPerChecklistId taskPerChecklistId;
+
+    @ManyToOne
+    @MapsId("checklistCode")
+    @JoinColumn(name = "checklist_code", insertable = false, updatable = false)
+    // @MapsId: 이 어노테이션은 엔티티의 복합 키(@EmbeddedId)에 매핑된 외래 키 필드를 나타냅니다.
+    // @MapsId("checklistCode")는 TaskPerChecklistId의 checklistCode 필드와 매핑됩니다.
+    // insertable = false, updatable = false 속성은 해당 필드가 외래 키로서 복합 키에 의해 관리됨을 나타냅니다.
+    private CheckList checkList;
+
+    @ManyToOne
+    @MapsId("taskCode")
+    @JoinColumn(name = "task_code", insertable = false, updatable = false)
+    private Task task;
+
+    @Column
+    private Boolean taskFinishedState;
+
+    @Column
+    private LocalDateTime createdAt;
+
+    @Column
+    private LocalDateTime updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "employee_code", nullable = false)
+    private Employee employee;  // 얘는 복합키는 아닌 그냥 외래키
+}

--- a/src/main/java/com/intbyte/wizbuddy/taskperchecklist/domain/entity/TaskPerChecklistId.java
+++ b/src/main/java/com/intbyte/wizbuddy/taskperchecklist/domain/entity/TaskPerChecklistId.java
@@ -1,0 +1,18 @@
+package com.intbyte.wizbuddy.taskperchecklist.domain.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+public class TaskPerChecklistId implements Serializable {
+
+    private Integer checklistCode;
+    private Integer taskCode;
+}

--- a/src/main/java/com/intbyte/wizbuddy/taskperchecklist/dto/TaskPerCheckListDTO.java
+++ b/src/main/java/com/intbyte/wizbuddy/taskperchecklist/dto/TaskPerCheckListDTO.java
@@ -1,0 +1,26 @@
+package com.intbyte.wizbuddy.taskperchecklist.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class TaskPerCheckListDTO {
+
+    private int checkListCode;
+
+    private int taskCode;
+
+    private Boolean taskFinishedState;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private int employeeCode;
+}

--- a/src/main/java/com/intbyte/wizbuddy/taskperchecklist/repository/TaskPerCheckListRepository.java
+++ b/src/main/java/com/intbyte/wizbuddy/taskperchecklist/repository/TaskPerCheckListRepository.java
@@ -1,0 +1,11 @@
+package com.intbyte.wizbuddy.taskperchecklist.repository;
+
+import com.intbyte.wizbuddy.taskperchecklist.domain.entity.TaskPerCheckList;
+import com.intbyte.wizbuddy.taskperchecklist.domain.entity.TaskPerChecklistId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskPerCheckListRepository extends JpaRepository<TaskPerCheckList, TaskPerChecklistId> {
+
+}

--- a/src/main/java/com/intbyte/wizbuddy/taskperchecklist/service/TaskPerCheckListService.java
+++ b/src/main/java/com/intbyte/wizbuddy/taskperchecklist/service/TaskPerCheckListService.java
@@ -1,0 +1,99 @@
+package com.intbyte.wizbuddy.taskperchecklist.service;
+
+import com.intbyte.wizbuddy.checklist.domain.entity.CheckList;
+import com.intbyte.wizbuddy.checklist.repository.CheckListRepository;
+import com.intbyte.wizbuddy.mapper.TaskPerCheckListMapper;
+import com.intbyte.wizbuddy.task.domain.entity.Task;
+import com.intbyte.wizbuddy.task.dto.TaskDTO;
+import com.intbyte.wizbuddy.task.repository.TaskRepository;
+import com.intbyte.wizbuddy.taskperchecklist.domain.entity.TaskPerCheckList;
+import com.intbyte.wizbuddy.taskperchecklist.domain.entity.TaskPerChecklistId;
+import com.intbyte.wizbuddy.taskperchecklist.dto.TaskPerCheckListDTO;
+import com.intbyte.wizbuddy.taskperchecklist.repository.TaskPerCheckListRepository;
+import com.intbyte.wizbuddy.user.domain.entity.Employee;
+import com.intbyte.wizbuddy.user.repository.EmployeeRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TaskPerCheckListService {
+
+    private final TaskPerCheckListRepository taskPerCheckListRepository;
+//    private final TaskPerCheckListMapper taskPerCheckListMapper;
+    private final ModelMapper modelMapper;
+
+    private CheckListRepository checkListRepository;
+
+    private TaskRepository taskRepository;
+
+    private EmployeeRepository employeeRepository;
+
+    @Autowired
+    public TaskPerCheckListService(CheckListRepository checkListRepository, TaskPerCheckListRepository taskPerCheckListRepository, /*TaskPerCheckListMapper taskPerCheckListMapper,*/ ModelMapper modelMapper, TaskRepository taskRepository, EmployeeRepository employeeRepository) {
+        this.checkListRepository = checkListRepository;
+        this.taskPerCheckListRepository = taskPerCheckListRepository;
+//        this.taskPerCheckListMapper = taskPerCheckListMapper;
+        this.modelMapper = modelMapper;
+        this.taskRepository = taskRepository;
+        this.employeeRepository = employeeRepository;
+    }
+
+    // 1번 체크리스트에 1번 업무 추가
+    @Transactional
+    public void insertTaskPerCheckList(TaskPerCheckListDTO taskPerCheckListDTO) {
+
+        TaskPerChecklistId taskPerChecklistId = new TaskPerChecklistId(
+                taskPerCheckListDTO.getCheckListCode(),
+                taskPerCheckListDTO.getTaskCode()
+        );
+
+        // CheckList, Task, Employee 객체 조회
+        CheckList checkList = checkListRepository.findById(taskPerCheckListDTO.getCheckListCode())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid checkListCode"));
+        Task task = taskRepository.findById(taskPerCheckListDTO.getTaskCode())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid taskCode"));
+        Employee employee = employeeRepository.findById(taskPerCheckListDTO.getEmployeeCode())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid employeeCode"));
+// 좀따가 생성해야함. -> employee 생성 후에
+
+        System.out.println("checkList = " + checkList);
+        System.out.println("task = " + task);
+        System.out.println("employee = " + employee);
+
+        TaskPerCheckList taskPerCheckList = TaskPerCheckList.builder()
+                .checkList(checkList)
+                .task(task)
+                .taskPerChecklistId(taskPerChecklistId)
+                .taskFinishedState(taskPerCheckListDTO.getTaskFinishedState())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .employee(employee)
+                .build();
+
+        taskPerCheckListRepository.save(taskPerCheckList);
+    }
+
+//    @Transactional
+//    public TaskPerCheckListDTO findTaskPerCheckListById(TaskPerChecklistId id) {
+//
+//
+//    }
+//
+//    @Transactional
+//    public List<TaskPerCheckListDTO> findAllTaskPerCheckLists() {
+//        List<TaskPerCheckList> list = taskPerCheckListMapper.findAllTaskPerCheckList();
+//
+//        return list.stream()
+//                .map(taskPerCheckList -> taskPerCheckListMapper
+//
+//
+//    }
+
+
+}

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/TaskPerCheckListMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/TaskPerCheckListMapper.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.intbyte.wizbuddy.mapper.TaskPerCheckListMapper">
+<!--    <resultMap id="findAllTaskPerCheckList" type="com.intbyte.wizbuddy.taskperchecklist.domain.entity.TaskPerCheckList">-->
+<!--        &lt;!&ndash; 복합 키 매핑 &ndash;&gt;-->
+<!--        <id property="taskPerChecklistId.taskCode" column="TASK_CODE"/>-->
+<!--        <id property="taskPerChecklistId.checkListCode" column="CHECKLIST_CODE"/>-->
+
+<!--        &lt;!&ndash; 나머지 필드 매핑 &ndash;&gt;-->
+<!--        <result property="taskFinishedState" column="TASK_FINISHED_STATE"/>-->
+<!--        <result property="createdAt" column="CREATED_AT"/>-->
+<!--        <result property="updatedAt" column="UPDATED_AT"/>-->
+
+<!--        &lt;!&ndash; 외래 키 매핑 (Task 엔티티와 연결) &ndash;&gt;-->
+<!--        <association property="task" javaType="com.intbyte.wizbuddy.task.domain.entity.Task">-->
+<!--            <id property="taskCode" column="TASK_CODE"/>-->
+<!--            &lt;!&ndash; Task 엔티티의 다른 필드들 매핑 가능 &ndash;&gt;-->
+<!--        </association>-->
+
+<!--        &lt;!&ndash; 외래 키 매핑 (CheckList 엔티티와 연결) &ndash;&gt;-->
+<!--        <association property="checkList" javaType="com.intbyte.wizbuddy.checklist.domain.entity.CheckList">-->
+<!--            <id property="checkListCode" column="CHECKLIST_CODE"/>-->
+<!--            &lt;!&ndash; CheckList 엔티티의 다른 필드들 매핑 가능 &ndash;&gt;-->
+<!--        </association>-->
+
+<!--        &lt;!&ndash; 일반 외래 키 매핑 (Employee 엔티티와 연결) &ndash;&gt;-->
+<!--        <association property="employee" javaType="com.intbyte.wizbuddy.employee.domain.entity.Employee" column="EMPLOYEE_CODE" />-->
+<!--    </resultMap>-->
+<!--&lt;!&ndash;    <select id="findAllTaskPerCheckList" resultMap="taskPerChecklistResultMap">&ndash;&gt;-->
+<!--&lt;!&ndash;        SELECT * FROM taskperchecklist&ndash;&gt;-->
+<!--&lt;!&ndash;    </select>&ndash;&gt;-->
+
+</mapper>

--- a/src/test/java/com/intbyte/wizbuddy/taskperchecklist/service/TaskPerCheckListServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/taskperchecklist/service/TaskPerCheckListServiceTests.java
@@ -1,0 +1,30 @@
+package com.intbyte.wizbuddy.taskperchecklist.service;
+
+import com.intbyte.wizbuddy.taskperchecklist.dto.TaskPerCheckListDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class TaskPerCheckListServiceTests {
+
+    @Autowired
+    private TaskPerCheckListService taskPerCheckListService;
+
+    @Test
+    @DisplayName("체크리스트에 업무추가 테스트 성공")
+    public void insertTaskPerCheckListTest(){
+        TaskPerCheckListDTO taskPerCheckListDTO = new TaskPerCheckListDTO(2, 5, true,
+                LocalDateTime.now(), LocalDateTime.now(), 14);
+
+        taskPerCheckListService.insertTaskPerCheckList(taskPerCheckListDTO);
+
+
+    }
+}


### PR DESCRIPTION
추후 jpa로 update, delete 확인 및 mybatis로 select 하는 구문 개발 필요

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
taskPerCheckList 중간 테이블을 위한 @ManytoOne mapping 후 insert 구문 생성 및 테스트 완료

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/aebbfdcb-af0a-41b7-a71b-62dda6612543)

## 테스트 계획 또는 완료 사항
- [x] 체크리스트에 업무추가 테스트 성공