### PR TITLE
✨ 기능 추가 : 대타게시판 조회, 등록, 수정, 삭제 기능 

### DIFF
--- a/src/main/java/com/intbyte/wizbuddy/board/domain/entity/SubsBoard.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/domain/entity/SubsBoard.java
@@ -1,5 +1,6 @@
 package com.intbyte.wizbuddy.board.domain.entity;
 
+import com.intbyte.wizbuddy.board.dto.SubsBoardDTO;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -11,32 +12,57 @@ import java.time.LocalDateTime;
 @Entity(name = "subsBoard")
 @Table(name = "substitutionBoard")
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
 public class SubsBoard {
     @Id
-    @Column
+    @Column(name = "subs_code")
     private int subsCode;
 
-    @Column
+    @Column(name = "subs_title")
     private String subsTitle;
 
-    @Column
-    private String subsContents;
+    @Column(name = "subs_content")
+    private String subsContent;
 
-    @Column
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    @Column
+    @Column(name = "subs_flag" )
     private boolean subsFlag;
 
-    @Column
+    @Column(name = "working_part_code")
     private int employeeWorkingPartCode;
 
-    @Column
+    @Column(name = "shop_code")
     private int shopCode;
+
+    public SubsBoard(SubsBoardDTO subsBoard) {
+        this.subsCode = subsBoard.getSubsCode();
+        this.subsTitle = subsBoard.getSubsTitle();
+        this.subsContent = subsBoard.getSubsContent();
+        this.createdAt = subsBoard.getCreatedAt();
+        this.updatedAt = subsBoard.getUpdatedAt();
+        this.subsFlag = subsBoard.isSubsFlag();
+        this.employeeWorkingPartCode = subsBoard.getEmployeeWorkingPartCode();
+        this.shopCode = subsBoard.getShopCode();
+    }
+
+
+    public void toUpdate(SubsBoardDTO dto) {
+        this.subsTitle = dto.getSubsTitle();
+        this.subsContent = dto.getSubsContent();
+        this.updatedAt = LocalDateTime.now();
+        this.employeeWorkingPartCode = dto.getEmployeeWorkingPartCode();
+    }
+
+    public void modifyFlag() {
+        this.subsFlag = false;
+    }
+
 }

--- a/src/main/java/com/intbyte/wizbuddy/board/domain/entity/SubsBoard.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/domain/entity/SubsBoard.java
@@ -42,17 +42,6 @@ public class SubsBoard {
     @Column(name = "shop_code")
     private int shopCode;
 
-    public SubsBoard(SubsBoardDTO subsBoard) {
-        this.subsCode = subsBoard.getSubsCode();
-        this.subsTitle = subsBoard.getSubsTitle();
-        this.subsContent = subsBoard.getSubsContent();
-        this.createdAt = subsBoard.getCreatedAt();
-        this.updatedAt = subsBoard.getUpdatedAt();
-        this.subsFlag = subsBoard.isSubsFlag();
-        this.employeeWorkingPartCode = subsBoard.getEmployeeWorkingPartCode();
-        this.shopCode = subsBoard.getShopCode();
-    }
-
 
     public void toUpdate(SubsBoardDTO dto) {
         this.subsTitle = dto.getSubsTitle();

--- a/src/main/java/com/intbyte/wizbuddy/board/dto/SubsBoardDTO.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/dto/SubsBoardDTO.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class SubsBoardDTO {
     private int subsCode;
     private String subsTitle;
-    private String subsContents;
+    private String subsContent;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private boolean subsFlag;

--- a/src/main/java/com/intbyte/wizbuddy/board/repository/SubsBoardRepository.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/repository/SubsBoardRepository.java
@@ -1,10 +1,9 @@
 package com.intbyte.wizbuddy.board.repository;
 
 import com.intbyte.wizbuddy.board.domain.entity.SubsBoard;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import org.springframework.data.jpa.repository.JpaRepository;
+
 public interface SubsBoardRepository extends JpaRepository<SubsBoard, Integer> {
 
 }

--- a/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
@@ -62,8 +62,13 @@ public class SubsBoardService {
         return subsBoard;
     }
 
-
-
+    @Transactional
+    public SubsBoard deleteSubsBoard(SubsBoardDTO deletesubsBoard) {
+        SubsBoard subsBoard = subsBoardRepository.findById(deletesubsBoard.getSubsCode()).orElseThrow(IllegalArgumentException::new);
+        subsBoard.modifyFlag();
+        subsBoardRepository.save(subsBoard);
+        return modelMapper.map(subsBoard, SubsBoard.class);
+    }
 
 
 

--- a/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
@@ -34,4 +34,16 @@ public class SubsBoardService {
     }
 
 
+    public SubsBoardDTO findSubsBoardById(int subsCode) {
+        SubsBoard subsBoard = subsBoardMapper.selectSubsBoardById(subsCode);
+
+        if (subsBoard == null) {
+            throw new IllegalArgumentException("해당 subsCode에 대한 게시판 항목을 찾을 수 없습니다.");
+        }
+
+        return modelMapper.map(subsBoard, SubsBoardDTO.class);
+    }
+
+
+
 }

--- a/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
@@ -1,4 +1,37 @@
 package com.intbyte.wizbuddy.board.service;
 
+import com.intbyte.wizbuddy.board.domain.entity.SubsBoard;
+import com.intbyte.wizbuddy.board.dto.SubsBoardDTO;
+import com.intbyte.wizbuddy.board.repository.SubsBoardRepository;
+import com.intbyte.wizbuddy.mapper.SubsBoardMapper;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
 public class SubsBoardService {
+
+    private final SubsBoardMapper subsBoardMapper;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public SubsBoardService(SubsBoardMapper subsBoardMapper, ModelMapper modelMapper) {
+        this.subsBoardMapper = subsBoardMapper;
+        this.modelMapper = modelMapper;
+    }
+
+
+    public List<SubsBoardDTO> findAllSubsBoards() {
+        List<SubsBoard> subsBoardList = subsBoardMapper.selectAllSubsBoard();
+
+        return subsBoardList.stream()
+                .map(subsBoard -> modelMapper.map(subsBoard, SubsBoardDTO.class))
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
@@ -8,6 +8,7 @@ import com.intbyte.wizbuddy.mapper.SubsBoardMapper;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,12 +18,15 @@ public class SubsBoardService {
 
     private final SubsBoardMapper subsBoardMapper;
     private final ModelMapper modelMapper;
+    private final SubsBoardRepository subsBoardRepository;
 
     @Autowired
-    public SubsBoardService(SubsBoardMapper subsBoardMapper, ModelMapper modelMapper) {
+    public SubsBoardService(SubsBoardMapper subsBoardMapper, ModelMapper modelMapper, SubsBoardRepository subsBoardRepository) {
         this.subsBoardMapper = subsBoardMapper;
         this.modelMapper = modelMapper;
+        this.subsBoardRepository = subsBoardRepository;
     }
+
 
 
     public List<SubsBoardDTO> findAllSubsBoards() {
@@ -43,6 +47,14 @@ public class SubsBoardService {
 
         return modelMapper.map(subsBoard, SubsBoardDTO.class);
     }
+
+
+    @Transactional
+    public SubsBoard registSubsBoard(SubsBoardDTO subsBoard) {
+        return subsBoardRepository.save(modelMapper.map(subsBoard, SubsBoard.class));
+    }
+
+
 
 
 

--- a/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
@@ -54,6 +54,15 @@ public class SubsBoardService {
         return subsBoardRepository.save(modelMapper.map(subsBoard, SubsBoard.class));
     }
 
+    @Transactional
+    public SubsBoard modifySubsBoards(SubsBoardDTO modifysubsBoard) {
+        SubsBoard subsBoard = subsBoardRepository.findById(modifysubsBoard.getSubsCode()).orElseThrow(IllegalArgumentException::new);
+        subsBoard.toUpdate(modifysubsBoard);
+        subsBoardRepository.save(modelMapper.map(subsBoard, SubsBoard.class));
+        return subsBoard;
+    }
+
+
 
 
 

--- a/src/main/java/com/intbyte/wizbuddy/mapper/SubsBoardMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/SubsBoardMapper.java
@@ -1,7 +1,14 @@
 package com.intbyte.wizbuddy.mapper;
 
+import com.intbyte.wizbuddy.board.domain.entity.SubsBoard;
+import com.intbyte.wizbuddy.board.dto.SubsBoardDTO;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface SubsBoardMapper {
+    List<SubsBoard> selectAllSubsBoard();
+    SubsBoard selectSubsBoardById(int subsCode);
+
 }

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
@@ -2,6 +2,29 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper>
+<mapper namespace="com.intbyte.wizbuddy.mapper.SubsBoardMapper">
+    <resultMap id="SubsBoardResultMap" type="com.intbyte.wizbuddy.board.dto.SubsBoardDTO">
+        <id property="subsCode" column="SUBSCODE"/>
+        <result property="subsTitle" column="SUBSTITLE"/>
+        <result property="subsContents" column="SUBSCONTENTS"/>
+        <result property="createdAt" column="CREATEDAT"/>
+        <result property="updatedAt" column="UPDATEDAT"/>
+        <result property="subsFlag" column="SUBSFLAG"/>
+        <result property="employeeWorkingPartCode" column="WORKINGPARTCODE"/>
+        <result property="shopCode" column="SHOPCODE"/>
+    </resultMap>
+
+    <select id="selectAllSubsBoard" resultMap="SubsBoardResultMap">
+        SELECT
+        SUBSCODE
+        , SUBSTITLE
+        , SUBSCONTENT
+        , CREATEDAT
+        , UPDATEDAT
+        , SUBSFLAG
+        , WORKINGPARTCODEㅁ
+        , SHOPCODE
+        FROM SUBSTITUATIONBOARD
+    </select>
 
 </mapper>

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
@@ -3,28 +3,29 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.intbyte.wizbuddy.mapper.SubsBoardMapper">
-    <resultMap id="SubsBoardResultMap" type="com.intbyte.wizbuddy.board.dto.SubsBoardDTO">
-        <id property="subsCode" column="SUBSCODE"/>
-        <result property="subsTitle" column="SUBSTITLE"/>
-        <result property="subsContents" column="SUBSCONTENTS"/>
-        <result property="createdAt" column="CREATEDAT"/>
-        <result property="updatedAt" column="UPDATEDAT"/>
-        <result property="subsFlag" column="SUBSFLAG"/>
-        <result property="employeeWorkingPartCode" column="WORKINGPARTCODE"/>
-        <result property="shopCode" column="SHOPCODE"/>
+    <resultMap id="SubsBoardResultMap" type="com.intbyte.wizbuddy.board.domain.entity.SubsBoard">
+        <id property="subsCode" column="SUBS_CODE"/>
+        <result property="subsTitle" column="SUBS_TITLE"/>
+        <result property="subsContent" column="SUBS_CONTENT"/>
+        <result property="createdAt" column="CREATED_AT"/>
+        <result property="updatedAt" column="UPDATED_AT"/>
+        <result property="subsFlag" column="SUBS_FLAG"/>
+        <result property="employeeWorkingPartCode" column="WORKING_PART_CODE"/>
+        <result property="shopCode" column="SHOP_CODE"/>
     </resultMap>
 
-    <select id="selectAllSubsBoard" resultMap="SubsBoardResultMap">
+    <select id="selectAllSubsBoard" resultMap="SubsBoardResultMap" >
         SELECT
-        SUBSCODE
-        , SUBSTITLE
-        , SUBSCONTENT
-        , CREATEDAT
-        , UPDATEDAT
-        , SUBSFLAG
-        , WORKINGPARTCODEㅁ
-        , SHOPCODE
-        FROM SUBSTITUATIONBOARD
+        S.SUBS_CODE
+        , S.SUBS_TITLE
+        , S.SUBS_CONTENT
+        , S.CREATED_AT
+        , S.UPDATED_AT
+        , S.SUBS_FLAG
+        , S.WORKING_PART_CODE
+        , S.SHOP_CODE
+        FROM SUBSTITUTION_BOARD S
     </select>
+
 
 </mapper>

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
@@ -27,5 +27,20 @@
         FROM SUBSTITUTION_BOARD S
     </select>
 
+    <select id="selectSubsBoardById" resultMap="SubsBoardResultMap" parameterType="_int">
+        SELECT
+        S.SUBS_CODE
+        , S.SUBS_TITLE
+        , S.SUBS_CONTENT
+        , S.CREATED_AT
+        , S.UPDATED_AT
+        , S.SUBS_FLAG
+        , S.WORKING_PART_CODE
+        , S.SHOP_CODE
+        FROM SUBSTITUTION_BOARD S
+        WHERE S.SUBS_CODE = #{ subsCode }
+    </select>
+
+
 
 </mapper>

--- a/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
@@ -1,13 +1,17 @@
 package com.intbyte.wizbuddy.board.service;
 
+import com.intbyte.wizbuddy.board.domain.entity.SubsBoard;
 import com.intbyte.wizbuddy.board.dto.SubsBoardDTO;
 
 import com.intbyte.wizbuddy.board.repository.SubsBoardRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,6 +52,39 @@ class SubsBoardServiceTests {
         System.out.println("조회된 게시판 제목: " + foundSubsBoard.getSubsTitle());
         System.out.println("조회된 게시판 내용: " + foundSubsBoard.getSubsContent());
     }
+
+
+    @Test
+    @Transactional
+    public void 대타게시판_등록_테스트() {
+        // given
+        SubsBoardDTO newSubsBoard = new SubsBoardDTO();
+        newSubsBoard.setSubsCode(3);
+        newSubsBoard.setSubsTitle("새로운 게시판 제목");
+        newSubsBoard.setSubsContent("게시판 내용");
+        newSubsBoard.setCreatedAt(LocalDateTime.now());
+        newSubsBoard.setUpdatedAt(LocalDateTime.now());
+        newSubsBoard.setEmployeeWorkingPartCode(1);
+        newSubsBoard.setSubsFlag(true);
+        newSubsBoard.setShopCode(1);
+
+        // when
+        SubsBoard savedSubsBoard = subsBoardService.registSubsBoard(newSubsBoard);
+
+        // then
+        assertNotNull(savedSubsBoard, "게시판 등록이 되어야 합니다.");
+        assertEquals("새로운 게시판 제목", savedSubsBoard.getSubsTitle());
+
+        SubsBoard foundSubsBoard = subsBoardRepository.findById(3)
+                .orElseThrow(() -> new IllegalArgumentException("해당 코드의 게시판이 존재하지 않습니다."));
+
+        assertEquals("새로운 게시판 제목", foundSubsBoard.getSubsTitle());
+        assertEquals("게시판 내용", foundSubsBoard.getSubsContent());
+        assertEquals(1, foundSubsBoard.getEmployeeWorkingPartCode());
+        assertEquals(true, foundSubsBoard.isSubsFlag());
+        assertEquals(1, foundSubsBoard.getShopCode());
+    }
+
 
 
 }

--- a/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -83,6 +82,37 @@ class SubsBoardServiceTests {
         assertEquals(1, foundSubsBoard.getEmployeeWorkingPartCode());
         assertEquals(true, foundSubsBoard.isSubsFlag());
         assertEquals(1, foundSubsBoard.getShopCode());
+    }
+
+
+    @Test
+    @Transactional
+    void 대타게시판_수정_테스트() {
+        // given
+        int subsCode = 2;
+
+        SubsBoardDTO existingBoardDTO = subsBoardService.findSubsBoardById(subsCode);
+
+        assertNotNull(existingBoardDTO, "게시판 데이터가 존재해야 합니다.");
+
+        existingBoardDTO.setSubsTitle("추석 3일 내내 알바할사람 이리오셈티비~");
+        existingBoardDTO.setSubsContent("댓글 컴온 베베");
+        existingBoardDTO.setEmployeeWorkingPartCode(3);
+
+        // when
+        SubsBoard updatedBoard = subsBoardService.modifySubsBoards(existingBoardDTO);
+
+        System.out.println("updatedBoard = " + updatedBoard);
+
+        // then
+        SubsBoard foundBoard = subsBoardRepository.findById(subsCode)
+                .orElseThrow(() -> new IllegalArgumentException("게시판을 찾을 수 없습니다."));
+
+        assertEquals("추석 3일 내내 알바할사람 이리오셈티비~", foundBoard.getSubsTitle());
+        assertEquals("댓글 컴온 베베", foundBoard.getSubsContent());
+        assertNotNull(foundBoard.getCreatedAt());
+        assertEquals(3, foundBoard.getEmployeeWorkingPartCode());
+        assertEquals(1, foundBoard.getShopCode());
     }
 
 

--- a/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
@@ -1,6 +1,5 @@
 package com.intbyte.wizbuddy.board.service;
 
-
 import com.intbyte.wizbuddy.board.dto.SubsBoardDTO;
 
 import com.intbyte.wizbuddy.board.repository.SubsBoardRepository;
@@ -9,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class SubsBoardServiceTests {
@@ -31,5 +32,22 @@ class SubsBoardServiceTests {
                 });
 
     }
+
+    @Test
+    public void 매장별_대타게시판_조회_테스트() {
+        // given
+        int subsCode = 1;
+
+        // when
+        SubsBoardDTO foundSubsBoard = subsBoardService.findSubsBoardById(subsCode);
+
+        // then
+        assertNotNull(foundSubsBoard, "해당 subsCode에 대한 대타게시판 항목을 찾을 수 없습니다.");
+        assertEquals(subsCode, foundSubsBoard.getSubsCode());
+
+        System.out.println("조회된 게시판 제목: " + foundSubsBoard.getSubsTitle());
+        System.out.println("조회된 게시판 내용: " + foundSubsBoard.getSubsContent());
+    }
+
 
 }

--- a/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -115,6 +116,27 @@ class SubsBoardServiceTests {
         assertEquals(1, foundBoard.getShopCode());
     }
 
+
+
+
+    @Test
+    @Transactional
+    void 대타게시판_삭제_테스트() {
+        // Given
+        int subsCode = 1;
+
+        SubsBoardDTO subsBoard = subsBoardService.findSubsBoardById(subsCode);
+        // When
+        SubsBoard result = subsBoardService.deleteSubsBoard(subsBoard);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.isSubsFlag()).isFalse();
+
+        SubsBoard updatedSubsBoard = subsBoardRepository.findById(subsCode).orElse(null);
+        assertThat(updatedSubsBoard).isNotNull();
+        assertThat(updatedSubsBoard.isSubsFlag()).isFalse();
+    }
 
 
 }

--- a/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
@@ -1,0 +1,35 @@
+package com.intbyte.wizbuddy.board.service;
+
+
+import com.intbyte.wizbuddy.board.dto.SubsBoardDTO;
+
+import com.intbyte.wizbuddy.board.repository.SubsBoardRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class SubsBoardServiceTests {
+
+
+    @Autowired
+    private SubsBoardService subsBoardService;
+
+    @Autowired
+    private SubsBoardRepository subsBoardRepository;
+
+
+
+    @Test
+    public void 대타게시판_전체_조회_테스트() {
+        Assertions.assertDoesNotThrow(
+                () -> {
+                    List<SubsBoardDTO> subsBoard = subsBoardService.findAllSubsBoards();
+                    subsBoard.forEach(System.out::println);
+                });
+
+    }
+
+}


### PR DESCRIPTION
---
name: 대타게시판 조회, 등록, 수정, 삭제 기능
about: 대타게시판을 전체 조회하고, 매장별 조회하고, 글을 등록하고, 수정하고, 삭제가 가능하다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [✅ ] 신규 기능
- [✅ ] 기능 수정

## 어떤 부분에 리뷰어가 집중하면 좋은가
-  조회, 등록, 수정, 삭제가 잘 작동 되는지 확인

## 테스트 계획 또는 완료 사항
- [✅  ] 대타 게시글 등록
- [✅  ] 대타 게시글 조회
- [✅  ] 대타 게시글 수정
- [✅  ] 대타 게시글 삭제

close #40 #41 #44 #46 
