### PR TITLE
✨ 기능 추가 : 매장별 대타게시글 모두 조회 테스트 기능 추가

### DIFF
--- a/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
@@ -25,26 +25,27 @@ public class SubsBoardService {
     private final SubsBoardRepository subsBoardRepository;
 
 
-
     public List<SubsBoardDTO> findAllSubsBoards() {
         List<SubsBoard> subsBoardList = subsBoardMapper.selectAllSubsBoard();
-
+        if (subsBoardList == null || subsBoardList.isEmpty() ) {throw new SubsBoardNotFoundException();}
         return subsBoardList.stream()
                 .map(subsBoard -> modelMapper.map(subsBoard, SubsBoardDTO.class))
                 .collect(Collectors.toList());
     }
 
-
     public SubsBoardDTO findSubsBoardById(int subsCode) {
         SubsBoard subsBoard = subsBoardMapper.selectSubsBoardById(subsCode);
-
-        if (subsBoard == null) {
-            throw new SubsBoardNotFoundException();
-        }
-
+        if (subsBoard == null) {throw new SubsBoardNotFoundException();}
         return modelMapper.map(subsBoard, SubsBoardDTO.class);
     }
 
+    public List<SubsBoardDTO> getSubsBoardsByShopCode(int shopCode) {
+        List<SubsBoard> subsBoards = subsBoardMapper.selectSubsBoardByShopCode(shopCode);
+        if (subsBoards == null || subsBoards.isEmpty()) {throw new SubsBoardNotFoundException();}
+        return subsBoards.stream()
+                .map(subsBoard -> modelMapper.map(subsBoard, SubsBoardDTO.class))
+                .collect(Collectors.toList());
+    }
 
     @Transactional
     public void registSubsBoard(SubsBoardDTO subsBoards) {

--- a/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/SubsBoardService.java
@@ -7,8 +7,8 @@ import com.intbyte.wizbuddy.board.repository.SubsBoardRepository;
 import com.intbyte.wizbuddy.exception.board.SubsBoardNotFoundException;
 import com.intbyte.wizbuddy.mapper.SubsBoardMapper;
 
+import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,18 +17,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class SubsBoardService {
 
     private final SubsBoardMapper subsBoardMapper;
     private final ModelMapper modelMapper;
     private final SubsBoardRepository subsBoardRepository;
-
-    @Autowired
-    public SubsBoardService(SubsBoardMapper subsBoardMapper, ModelMapper modelMapper, SubsBoardRepository subsBoardRepository) {
-        this.subsBoardMapper = subsBoardMapper;
-        this.modelMapper = modelMapper;
-        this.subsBoardRepository = subsBoardRepository;
-    }
 
 
 

--- a/src/main/java/com/intbyte/wizbuddy/comment/service/CommentService.java
+++ b/src/main/java/com/intbyte/wizbuddy/comment/service/CommentService.java
@@ -26,6 +26,7 @@ public class CommentService {
 
     public List<CommentDTO> findAllComment() {
         List<Comment> commentList = commentMapper.selectAllComment();
+        if(commentList == null || commentList.isEmpty()) {throw new CommentNotFoundException();}
         return  commentList.stream()
                 .map(comment-> modelMapper.map(comment, CommentDTO.class))
                 .collect(Collectors.toList());
@@ -33,11 +34,24 @@ public class CommentService {
 
     public CommentDTO findCommentById(int code) {
         Comment comment = commentMapper.selectCommentById(code);
-        if(comment == null) {
-            throw new CommentNotFoundException();
-
-        }
+        if(comment == null) {throw new CommentNotFoundException();}
         return modelMapper.map(comment, CommentDTO.class);
+    }
+
+    public List<CommentDTO> getCommentsBySubsCode(int subsCode) {
+        List<Comment> comments = commentMapper.selectCommentBySubsCode(subsCode);
+        if(comments == null || comments.isEmpty()) {throw new CommentNotFoundException();}
+        return comments.stream()
+                .map(comment -> modelMapper.map(comment, CommentDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    public List<CommentDTO> getCommentsByEmployeeCode(String employeeCode) {
+        List<Comment> comments = commentMapper.selectCommentByEmployeeCode(employeeCode);
+        if(comments == null || comments.isEmpty()) {throw new CommentNotFoundException();}
+        return comments.stream()
+                .map(comment -> modelMapper.map(comment, CommentDTO.class))
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/intbyte/wizbuddy/comment/service/CommentService.java
+++ b/src/main/java/com/intbyte/wizbuddy/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.intbyte.wizbuddy.comment.dto.CommentDTO;
 import com.intbyte.wizbuddy.comment.repository.CommentRepository;
 import com.intbyte.wizbuddy.exception.comment.CommentNotFoundException;
 import com.intbyte.wizbuddy.mapper.CommentMapper;
+import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,17 +16,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class CommentService {
 
     private final CommentMapper commentMapper;
     private final ModelMapper modelMapper;
     private final CommentRepository commentRepository;
 
-    public CommentService(CommentMapper commentMapper, ModelMapper modelMapper,CommentRepository commentRepository) {
-        this.commentMapper = commentMapper;
-        this.modelMapper = modelMapper;
-        this.commentRepository = commentRepository;
-    }
 
     public List<CommentDTO> findAllComment() {
         List<Comment> commentList = commentMapper.selectAllComment();

--- a/src/main/java/com/intbyte/wizbuddy/exception/board/SubsBoardNotFoundException.java
+++ b/src/main/java/com/intbyte/wizbuddy/exception/board/SubsBoardNotFoundException.java
@@ -6,7 +6,7 @@ public class SubsBoardNotFoundException extends IllegalArgumentException{
 
     private final StatusEnum status;
 
-    private static final String message = "해당 게시글이 존재하지 않습니다.";
+    private static final String message = "해당 대타 게시글이 존재하지 않습니다.";
 
     public SubsBoardNotFoundException() {
         super(message);

--- a/src/main/java/com/intbyte/wizbuddy/mapper/CommentMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/CommentMapper.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface CommentMapper {
     List<Comment> selectAllComment();
     Comment selectCommentById(int code);
+    List<Comment> selectCommentBySubsCode(int subsCode);
+    List<Comment> selectCommentByEmployeeCode(String employeeCode);
 }

--- a/src/main/java/com/intbyte/wizbuddy/mapper/SubsBoardMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/SubsBoardMapper.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface SubsBoardMapper {
     List<SubsBoard> selectAllSubsBoard();
     SubsBoard selectSubsBoardById(int subsCode);
-
+    List<SubsBoard> selectSubsBoardByShopCode(int shopCode);
 }

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/CommentMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/CommentMapper.xml
@@ -25,6 +25,7 @@
         , C.SUBS_CODE
         , C.EMPLOYEE_CODE
         FROM COMMENTS C
+        ORDER BY C.CREATED_AT DESC
     </select>
 
     <select id="selectCommentById" resultMap="CommentResultMap" >
@@ -40,5 +41,42 @@
         FROM COMMENTS C
         WHERE C.COMMENT_CODE = #{ commentCode }
     </select>
+
+
+    <select id="selectCommentByEmployeeCode" resultMap="CommentResultMap" parameterType="String">
+        SELECT
+        C.COMMENT_CODE
+        , C.COMMENT_CONTENTS
+        , C.COMMENT_FLAG
+        , C.COMMENT_ADOPTED_STATE
+        , C.CREATED_AT
+        , C.UPDATED_AT
+        , C.SUBS_CODE
+        , C.EMPLOYEE_CODE
+        FROM COMMENTS C
+        JOIN EMPLOYEE E ON C.EMPLOYEE_CODE = E.EMPLOYEE_CODE
+        WHERE E.EMPLOYEE_CODE = #{employeeCode}
+        AND C.COMMENT_FLAG = TRUE
+        ORDER BY C.CREATED_AT DESC
+    </select>
+
+
+    <select id="selectCommentBySubsCode" resultMap="CommentResultMap" parameterType="int">
+        SELECT
+        C.COMMENT_CODE
+        , C.COMMENT_CONTENTS
+        , C.COMMENT_FLAG
+        , C.COMMENT_ADOPTED_STATE
+        , C.CREATED_AT
+        , C.UPDATED_AT
+        , C.SUBS_CODE
+        , C.EMPLOYEE_CODE
+        FROM COMMENTS C
+        JOIN SUBSTITUTION_BOARD S ON C.SUBS_CODE = S.SUBS_CODE
+        WHERE S.SUBS_CODE = #{subsCode}
+        AND C.COMMENT_FLAG = TRUE
+        ORDER BY C.CREATED_AT DESC
+    </select>
+
 
 </mapper>

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/SubsBoardMapper.xml
@@ -25,9 +25,10 @@
         , S.WORKING_PART_CODE
         , S.SHOP_CODE
         FROM SUBSTITUTION_BOARD S
+        ORDER BY S.CREATED_AT DESC
     </select>
 
-    <select id="selectSubsBoardById" resultMap="SubsBoardResultMap" parameterType="_int">
+    <select id="selectSubsBoardById" resultMap="SubsBoardResultMap" parameterType="int">
         SELECT
         S.SUBS_CODE
         , S.SUBS_TITLE
@@ -41,6 +42,21 @@
         WHERE S.SUBS_CODE = #{ subsCode }
     </select>
 
-
+    <select id="selectSubsBoardByShopCode" resultMap="SubsBoardResultMap" parameterType="int">
+        SELECT
+        S.SUBS_CODE
+        , S.SUBS_TITLE
+        , S.SUBS_CONTENT
+        , S.CREATED_AT
+        , S.UPDATED_AT
+        , S.SUBS_FLAG
+        , S.WORKING_PART_CODE
+        , S.SHOP_CODE
+        FROM SUBSTITUTION_BOARD S
+        JOIN SHOP P ON S.SHOP_CODE = P.SHOP_CODE
+        WHERE  P.SHOP_CODE = #{shopCode}
+        AND S.SUBS_FLAG = TRUE
+        ORDER BY S.SHOP_CODE ASC
+    </select>
 
 </mapper>

--- a/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/SubsBoardServiceTests.java
@@ -20,19 +20,19 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 class SubsBoardServiceTests {
 
-
     @Autowired
     private SubsBoardService subsBoardService;
 
     @Autowired
     private SubsBoardRepository subsBoardRepository;
+
     @Autowired
     private SubsBoardMapper subsBoardMapper;
-
 
     @Test
     @DisplayName("대타게시판_전체_조회_테스트")
     public void findAllSubsBoardTest() {
+
         Assertions.assertDoesNotThrow(
                 () -> {
                     List<SubsBoardDTO> subsBoard = subsBoardService.findAllSubsBoards();
@@ -44,25 +44,38 @@ class SubsBoardServiceTests {
     @Test
     @DisplayName("대타게시판_1개_조회_테스트")
     public void findSubsBoardByIdTest() {
+
         // given
         int subsCode = 1;
-
         // when
         SubsBoardDTO foundSubsBoard = subsBoardService.findSubsBoardById(subsCode);
-
         // then
         assertNotNull(foundSubsBoard);
         assertEquals(subsCode, foundSubsBoard.getSubsCode());
-
         System.out.println("조회된 게시판 제목: " + foundSubsBoard.getSubsTitle());
         System.out.println("조회된 게시판 내용: " + foundSubsBoard.getSubsContent());
+
     }
 
+    @Test
+    @DisplayName("매장별_조회_테스트")
+    public void findSubsBoardByShopCodeTest() {
+
+        // given
+        int shopCode = 1;
+        // when
+        List<SubsBoardDTO> subsBoards = subsBoardService.getSubsBoardsByShopCode(shopCode);
+        // then
+        assertNotNull(subsBoards);
+        assertTrue(!subsBoards.isEmpty());
+
+    }
 
     @Test
     @Transactional
     @DisplayName("대타게시판_등록_테스트")
     public void insertSubsBoardTest() {
+
         // given
         List<SubsBoard> subsBoardList = subsBoardRepository.findAll();
         SubsBoardDTO newSubsBoard = new SubsBoardDTO(subsBoardList.size()+1,
@@ -80,13 +93,14 @@ class SubsBoardServiceTests {
         assertEquals(1, subsBoard.getEmployeeWorkingPartCode());
         assertEquals(true, subsBoard.isSubsFlag());
         assertEquals(1, subsBoard.getShopCode());
-    }
 
+    }
 
     @Test
     @Transactional
     @DisplayName("대타게시판_수정_테스트")
     void modifySubsBoardTest() {
+
         // given
         int subsCode = 1;
         SubsBoard subsBoard = subsBoardMapper.selectSubsBoardById(subsCode);
@@ -102,13 +116,14 @@ class SubsBoardServiceTests {
         assertNotNull(foundBoard.getCreatedAt());
         assertEquals(2, foundBoard.getEmployeeWorkingPartCode());
         assertEquals(1, foundBoard.getShopCode());
-    }
 
+    }
 
     @Test
     @Transactional
     @DisplayName("대타게시판_삭제_테스트")
     void deleteSubsBoardTest() {
+
         // given
         int subsCode = 1;
         SubsBoardDTO subsBoard = subsBoardService.findSubsBoardById(subsCode);
@@ -118,6 +133,7 @@ class SubsBoardServiceTests {
         SubsBoard updatedSubsBoard = subsBoardRepository.findById(subsCode).orElse(null);
         assertThat(updatedSubsBoard).isNotNull();
         assertThat(updatedSubsBoard.isSubsFlag()).isFalse();
+
     }
 
 }

--- a/src/test/java/com/intbyte/wizbuddy/comment/service/CommentServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/comment/service/CommentServiceTests.java
@@ -5,7 +5,6 @@ import com.intbyte.wizbuddy.comment.domain.Entity.Comment;
 import com.intbyte.wizbuddy.comment.dto.CommentDTO;
 import com.intbyte.wizbuddy.comment.repository.CommentRepository;
 import com.intbyte.wizbuddy.mapper.CommentMapper;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,8 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class CommentServiceTests {
@@ -35,6 +33,7 @@ class CommentServiceTests {
     @Test
     @DisplayName("댓글_전체_조회_테스트")
     public void findAllCommentTest() {
+
         Assertions.assertDoesNotThrow(
                 () -> {
                     List<CommentDTO> comments = commentService.findAllComment();
@@ -46,6 +45,7 @@ class CommentServiceTests {
     @Test
     @DisplayName("댓글_1개_조회_테스트")
     public void findCommentByIdTest(){
+
         //given
         int commentCode = 1;
         //when
@@ -53,7 +53,34 @@ class CommentServiceTests {
         //then
         assertNotNull(comment);
         assertNotNull(comment);
-        System.out.println("comment = " + comment);
+
+    }
+
+    @Test
+    @DisplayName("게시글별_댓글_모두_조회_테스트")
+    public void findCommentBySubsBoardTest() {
+
+        // given
+        int subsCode = 2;
+        // when
+        List<CommentDTO> comments = commentService.getCommentsBySubsCode(subsCode);
+        // then
+        assertNotNull(comments);
+        assertTrue(!comments.isEmpty());
+
+    }
+
+    @Test
+    @DisplayName("직원별_댓글_모두_조회_테스트")
+    public void findCommentByEmployeeTest() {
+
+        // given
+        String employeeCode = "20240831-471e-4fde-9c53-4b76b34777fd";
+        // when
+        List<CommentDTO> comments = commentService.getCommentsByEmployeeCode(employeeCode);
+        // then
+        assertNotNull(comments);
+        assertTrue(!comments.isEmpty());
 
     }
 
@@ -64,12 +91,13 @@ class CommentServiceTests {
 
         //given
         List<Comment> commentList = commentRepository.findAll();
-        CommentDTO comment = new CommentDTO(commentList.size() +1,"사장님 저 믿으시죠 저 가능합니다.",true,false, LocalDateTime.now(), LocalDateTime.now(),1,"20240831-f409-40b1-a03d-4d14d52fa13a");
-
+        CommentDTO comment = new CommentDTO(commentList.size() +1,
+                "사장님 저 믿으시죠 저 가능합니다.",true,
+                false, LocalDateTime.now(), LocalDateTime.now(),1,
+                "20240831-f409-40b1-a03d-4d14d52fa13a");
         //when
         System.out.println("comment = " + comment);
         commentService.registerComment(comment);
-
         //then
         List<Comment> newcomments = commentRepository.findAll();
         Comment newcomment = newcomments.get(newcomments.size()-1);
@@ -83,21 +111,25 @@ class CommentServiceTests {
     @DisplayName("댓글_수정_테스트")
     @Transactional
     public void modifyCommentTest() {
+
         //given
         int commentCode = 1;
         Comment comment = commentMapper.selectCommentById(commentCode);
-        EditCommentInfo updateComment = new EditCommentInfo( "사장님 ㅋㅋ 저할거랑께요?", false, LocalDateTime.now());
+        EditCommentInfo updateComment = new EditCommentInfo( "사장님 ㅋㅋ 저할거랑께요?",
+                false, LocalDateTime.now());
         //when
         commentService.modifyComment(comment.getCommentCode(), updateComment);
         //when
         Comment newcomment = commentRepository.findById(commentCode).orElse(null);
         assertEquals(updateComment.getCommentContent(),newcomment.getCommentContent());
+
     }
 
     @Test
     @DisplayName("댓글_삭제_테스트")
     @Transactional
     public void deleteCommentTest() {
+
         // given
         int subsCode = 1;
         CommentDTO comment = commentService.findCommentById(subsCode);


### PR DESCRIPTION
---
name: 게시판, 댓글 Join 조회
about: 
게시판 ->  직원파트번호, 매장번호  --> 내림차순 정렬, 상태=true 조건
게시글별 댓글을 모두 조회할 수 있어야 한다.  

댓글 -> 게시글 번호, 직원 번호  ---> 내림차순 정렬, 상태=true 조건
직원별 댓글을 모두 조회할 수 있어야한다. 
매장별 게시판 모두 조회 할 수 있어야 한다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [✅ ] 신규 기능
- [✅ ] 기능 수정

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 모든 추가 조회 기능이 잘 작동되는가 

## 관련 스크린 샷 

![image](https://github.com/user-attachments/assets/258f99c2-ef12-4715-a4c9-b0adc0f4413c)
![image](https://github.com/user-attachments/assets/8a66c430-31f7-4911-a67f-d690cf86ca40)


## 테스트 계획 또는 완료 사항
- [✅ ] 게시판별 댓글 조회
- [✅] 직원별 댓글 조회
- [✅] 매장별 대타게시판 조회

close #56 
close #58 
close #53 
close #51 
close #49 
close #46 
close #44 
close #41 
close #40 
