### PR TITLE
✨ 기능 추가: 공지사항 게시글 좋아요, 매뉴얼 게시글 좋아요 기능 및 테스트코드 추가

### DIFF
--- a/src/main/java/com/intbyte/wizbuddy/board/domain/entity/ManualBoardLiked.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/domain/entity/ManualBoardLiked.java
@@ -1,0 +1,35 @@
+package com.intbyte.wizbuddy.board.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "manualBoardLiked")
+@Table(name = "manualboardliked")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class ManualBoardLiked {
+
+    @Id
+    @Column
+    private int manualLikedCode;
+
+    @Column
+    private LocalDateTime createdAt;
+
+    @Column
+    private int manualCode;
+
+    @Column
+    private int shopCode;
+
+    @Column
+    private String employeeCode;
+}

--- a/src/main/java/com/intbyte/wizbuddy/board/domain/entity/NoticeBoardLiked.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/domain/entity/NoticeBoardLiked.java
@@ -1,0 +1,35 @@
+package com.intbyte.wizbuddy.board.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "noticeBoardLiked")
+@Table(name = "noticeboardliked")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class NoticeBoardLiked {
+
+    @Id
+    @Column
+    private int noticeLikedCode;
+
+    @Column
+    private LocalDateTime createdAt;
+
+    @Column
+    private int shopCode;
+
+    @Column
+    private int noticeCode;
+
+    @Column
+    private String employeeCode;
+}

--- a/src/main/java/com/intbyte/wizbuddy/board/dto/ManualBoardLikedDTO.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/dto/ManualBoardLikedDTO.java
@@ -1,0 +1,18 @@
+package com.intbyte.wizbuddy.board.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class ManualBoardLikedDTO {
+    private int manualLikedCode;
+    private LocalDateTime createdAt;
+    private int manualCode;
+    private int shopCode;
+    private String employeeCode;
+}

--- a/src/main/java/com/intbyte/wizbuddy/board/dto/NoticeBoardLikedDTO.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/dto/NoticeBoardLikedDTO.java
@@ -1,0 +1,18 @@
+package com.intbyte.wizbuddy.board.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class NoticeBoardLikedDTO {
+    private int noticeLikedCode;
+    private LocalDateTime createdAt;
+    private int shopCode;
+    private int noticeCode;
+    private String employeeCode;
+}

--- a/src/main/java/com/intbyte/wizbuddy/board/repository/ManualBoardLikedRepository.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/repository/ManualBoardLikedRepository.java
@@ -1,0 +1,9 @@
+package com.intbyte.wizbuddy.board.repository;
+
+import com.intbyte.wizbuddy.board.domain.entity.ManualBoardLiked;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ManualBoardLikedRepository extends JpaRepository<ManualBoardLiked, Integer> {
+}

--- a/src/main/java/com/intbyte/wizbuddy/board/repository/NoticeBoardLikedRepository.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/repository/NoticeBoardLikedRepository.java
@@ -1,0 +1,9 @@
+package com.intbyte.wizbuddy.board.repository;
+
+import com.intbyte.wizbuddy.board.domain.entity.NoticeBoardLiked;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeBoardLikedRepository extends JpaRepository<NoticeBoardLiked, Integer> {
+}

--- a/src/main/java/com/intbyte/wizbuddy/board/service/ManualBoardLikedService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/ManualBoardLikedService.java
@@ -1,0 +1,37 @@
+package com.intbyte.wizbuddy.board.service;
+
+import com.intbyte.wizbuddy.board.domain.entity.ManualBoardLiked;
+import com.intbyte.wizbuddy.board.dto.ManualBoardLikedDTO;
+import com.intbyte.wizbuddy.board.repository.ManualBoardLikedRepository;
+import com.intbyte.wizbuddy.mapper.ManualBoardLikedMapper;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class ManualBoardLikedService {
+
+    private final ManualBoardLikedRepository manualBoardLikedRepository;
+
+    public ManualBoardLikedService(ManualBoardLikedRepository manualBoardLikedRepository) {
+        this.manualBoardLikedRepository = manualBoardLikedRepository;
+    }
+
+    /* 기능. 1. 매뉴얼 게시글 좋아요 추가 */
+    @Transactional
+    public void registerManualBoardLike(ManualBoardLikedDTO manualBoardLikedInfo) {
+
+        ManualBoardLiked manualBoardLiked = ManualBoardLiked.builder()
+                .manualLikedCode(manualBoardLikedInfo.getManualLikedCode())
+                .createdAt(LocalDateTime.now())
+                .manualCode(manualBoardLikedInfo.getManualCode())
+                .shopCode(manualBoardLikedInfo.getShopCode())
+                .employeeCode(manualBoardLikedInfo.getEmployeeCode())
+                .build();
+
+        manualBoardLikedRepository.save(manualBoardLiked);
+    }
+
+
+}

--- a/src/main/java/com/intbyte/wizbuddy/board/service/NoticeBoardLikedService.java
+++ b/src/main/java/com/intbyte/wizbuddy/board/service/NoticeBoardLikedService.java
@@ -1,0 +1,35 @@
+package com.intbyte.wizbuddy.board.service;
+
+import com.intbyte.wizbuddy.board.domain.entity.NoticeBoardLiked;
+import com.intbyte.wizbuddy.board.dto.NoticeBoardLikedDTO;
+import com.intbyte.wizbuddy.board.repository.NoticeBoardLikedRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class NoticeBoardLikedService {
+
+    private final NoticeBoardLikedRepository noticeBoardLikedRepository;
+
+
+    public NoticeBoardLikedService(NoticeBoardLikedRepository noticeBoardLikedRepository) {
+        this.noticeBoardLikedRepository = noticeBoardLikedRepository;
+    }
+
+    /* 기능. 1. 공지사항 게시글 좋아요 추가 */
+    @Transactional
+    public void registerNoticeBoardLike(NoticeBoardLikedDTO noticeBoardLikedInfo) {
+
+        NoticeBoardLiked noticeBoardLiked = NoticeBoardLiked.builder()
+                                           .noticeLikedCode(noticeBoardLikedInfo.getNoticeCode())
+                                           .createdAt(LocalDateTime.now())
+                                           .employeeCode(noticeBoardLikedInfo.getEmployeeCode())
+                                           .shopCode(noticeBoardLikedInfo.getShopCode())
+                                           .noticeCode(noticeBoardLikedInfo.getNoticeCode())
+                                           .build();
+
+        noticeBoardLikedRepository.save(noticeBoardLiked);
+    }
+}

--- a/src/main/java/com/intbyte/wizbuddy/mapper/ManualBoardLikedMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/ManualBoardLikedMapper.java
@@ -1,0 +1,7 @@
+package com.intbyte.wizbuddy.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ManualBoardLikedMapper {
+}

--- a/src/main/java/com/intbyte/wizbuddy/mapper/NoticeBoardLikedMapper.java
+++ b/src/main/java/com/intbyte/wizbuddy/mapper/NoticeBoardLikedMapper.java
@@ -1,0 +1,7 @@
+package com.intbyte.wizbuddy.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface NoticeBoardLikedMapper {
+}

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/ManualBoardLikedMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/ManualBoardLikedMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.intbyte.wizbuddy.mapper.ManualBoardLikedMapper">
+    <resultMap id="manualBoardLikedResultMap" type="com.intbyte.wizbuddy.board.domain.entity.ManualBoardLiked">
+        <id property="manualLikedCode" column="manual_liked_code"/>
+        <result property="createdAt" column="created_at"/>
+        <association property="manualBoard" javaType="com.intbyte.wizbuddy.board.dto.ManualBoardDTO">
+            <id property="manualCode" column="manual_code"/>
+        </association>
+        <association property="shop" javaType="com.intbyte.wizbuddy.shop.dto.ShopDTO">
+            <id property="shopCode" column="shop_code"/>
+        </association>
+        <association property="employee" javaType="com.intbyte.wizbuddy.user.dto.EmployeeDTO">
+            <id property="employeeCode" column="employee_code"/>
+        </association>
+    </resultMap>
+</mapper>

--- a/src/main/resources/com/intbyte/wizbuddy/mapper/NoticeBoardLikedMapper.xml
+++ b/src/main/resources/com/intbyte/wizbuddy/mapper/NoticeBoardLikedMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.intbyte.wizbuddy.mapper.NoticeBoardLikedMapper">
+    <resultMap id="noticeBoardLikedResultMap" type="com.intbyte.wizbuddy.board.domain.entity.NoticeBoardLiked">
+        <id property="noticeLikedCode" column="notice_liked_code"/>
+        <result property="createdAt" column="created_at"/>
+        <association property="shop" javaType="com.intbyte.wizbuddy.shop.dto.ShopDTO">
+            <id property="shopCode" column="shop_code"/>
+        </association>
+        <association property="noticeBoard" javaType="com.intbyte.wizbuddy.board.dto.NoticeBoardDTO">
+            <id property="noticeCode" column="notice_code"/>
+        </association>
+        <association property="employee" javaType="com.intbyte.wizbuddy.user.dto.EmployeeDTO">
+            <id property="employeeCode" column="employee_code"/>
+        </association>
+    </resultMap>
+
+
+</mapper>

--- a/src/test/java/com/intbyte/wizbuddy/board/service/ManualBoardLikedServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/ManualBoardLikedServiceTests.java
@@ -1,0 +1,47 @@
+package com.intbyte.wizbuddy.board.service;
+
+import com.intbyte.wizbuddy.board.domain.entity.ManualBoardLiked;
+import com.intbyte.wizbuddy.board.dto.ManualBoardLikedDTO;
+import com.intbyte.wizbuddy.board.repository.ManualBoardLikedRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ManualBoardLikedServiceTests {
+
+    @Autowired
+    private ManualBoardLikedService manualBoardLikedService;
+
+    @Autowired
+    private ManualBoardLikedRepository manualBoardLikedRepository;
+
+    @Test
+    @DisplayName("매뉴얼 게시글 좋아요 추가 성공")
+    @Transactional
+    public void testRegisterManualBoardLike() {
+
+        List<ManualBoardLiked> manualBoardLiked = manualBoardLikedRepository.findAll();
+        int lastNum = manualBoardLiked.size();
+
+        ManualBoardLikedDTO manualBoardLikedInfo = new ManualBoardLikedDTO(lastNum, LocalDateTime.now(), 1, 1, "20240831-187e-452d-88b4-62b7469c1cfa");
+
+        manualBoardLikedService.registerManualBoardLike(manualBoardLikedInfo);
+
+        List<ManualBoardLiked> newManualBoardLiked = manualBoardLikedRepository.findAll();
+        int newLastNum = newManualBoardLiked.size();
+
+        assertEquals(newLastNum, manualBoardLikedRepository.findAll().size());
+
+        newManualBoardLiked.forEach(System.out::println);
+
+    }
+
+}

--- a/src/test/java/com/intbyte/wizbuddy/board/service/NoticeBoardLikedServiceTests.java
+++ b/src/test/java/com/intbyte/wizbuddy/board/service/NoticeBoardLikedServiceTests.java
@@ -1,0 +1,46 @@
+package com.intbyte.wizbuddy.board.service;
+
+import com.intbyte.wizbuddy.board.domain.entity.NoticeBoardLiked;
+import com.intbyte.wizbuddy.board.dto.NoticeBoardLikedDTO;
+import com.intbyte.wizbuddy.board.repository.NoticeBoardLikedRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class NoticeBoardLikedServiceTests {
+
+    @Autowired
+    private NoticeBoardLikedService noticeBoardLikedService;
+
+    @Autowired
+    private NoticeBoardLikedRepository noticeBoardLikedRepository;
+
+    @Test
+    @DisplayName("공지사항 게시글 좋아요 추가 성공")
+    @Transactional
+    public void testRegisterNoticeBoardLike() {
+
+        List<NoticeBoardLiked> noticeBoardLiked = noticeBoardLikedRepository.findAll();
+        int lastNum = noticeBoardLiked.size();
+
+        NoticeBoardLikedDTO noticeBoardLikedInfo = new NoticeBoardLikedDTO(lastNum, LocalDateTime.now(), 1, 1, "20240831-07de-4b18-95c6-564cd86a5af2");
+
+        noticeBoardLikedService.registerNoticeBoardLike(noticeBoardLikedInfo);
+
+        List<NoticeBoardLiked> newNoticeBoardLiked = noticeBoardLikedRepository.findAll();
+        int newLastNum = newNoticeBoardLiked.size();
+
+        assertEquals(newLastNum, noticeBoardLikedRepository.findAll().size());
+
+        newNoticeBoardLiked.forEach(System.out::println);
+    }
+
+}


### PR DESCRIPTION
---
name: 공지사항 게시글 좋아요, 매뉴얼 게시글 좋아요 기능 및 테스트코드 추가
about: 회원은 공지사항 게시글, 매뉴얼 게시글에 좋아요를 할 수 있다. 한 번 좋아요를 한 경우에는 취소할 수 없다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/115f24b4-c77d-4ae2-870a-e741366d00fd)
![image](https://github.com/user-attachments/assets/daffc2b2-80e8-4e18-a21b-cb182a4f8a9b)

## 테스트 계획 또는 완료 사항
- [x] 테스트항목 1
